### PR TITLE
Update actions versions and MDA versions in env

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -26,9 +26,9 @@ defaults:
     shell: bash -l {0}
 
 env:
-  MDANALYSIS_DEVELOP_VERSION: "2.8.0-dev0"
-  MDANALYSIS_LATEST_RELEASE: "2.7.0"
-  MDANALYSIS_PREVIOUS_RELEASE: "2.6.1"
+  MDANALYSIS_DEVELOP_VERSION: "2.11.0-dev0"
+  MDANALYSIS_LATEST_RELEASE: "2.10.0"
+  MDANALYSIS_PREVIOUS_RELEASE: "2.9.0"
 
 jobs:
   gen-python-matrix:
@@ -39,7 +39,7 @@ jobs:
       oldest-python: ${{ steps.get-compatible-python.outputs.oldest-python }}
       stable-python: ${{ steps.get-compatible-python.outputs.stable-python }}
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -78,7 +78,7 @@ jobs:
             mdanalysis-version: "latest"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - id: environment-setup
       run: |
@@ -123,7 +123,7 @@ jobs:
 
     - name: Setup Python ${{ matrix.python-version }}
       if: ${{ matrix.installer == 'pip' }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -162,7 +162,7 @@ jobs:
     needs: gen-python-matrix
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Install mamba Python ${{ needs.gen-python-matrix.outputs.stable-python }}
         uses: mamba-org/provision-with-micromamba@main
@@ -194,10 +194,10 @@ jobs:
     needs: gen-python-matrix
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Setup Python ${{ needs.gen-python-matrix.outputs.stable-python }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ needs.gen-python-matrix.outputs.stable-python }}
 

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -111,7 +111,7 @@ jobs:
 
     - name: Install conda Python ${{ matrix.python-version }}
       if: ${{ matrix.installer == 'conda' }}
-      uses: conda-incubator/setup-miniconda@v3
+      uses: conda-incubator/setup-miniconda@v4
       with:
         python-version: ${{ matrix.python-version }}
         add-pip-as-python-dependency: true

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ steps:
 - uses: actions/checkout@v6
 
 - name: Install conda Python 3.11
-  uses: conda-incubator/setup-miniconda@v2
+  uses: conda-incubator/setup-miniconda@v4
   with:
   python-version: 3.11
   add-pip-as-python-dependency: true

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Examples:
 The below workflow installs the develop version of MDAnalysis and MDAnalysisTests, using pip.
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v6
 
-- uses: actions/setup-python@v4
+- uses: actions/setup-python@v6
   with:
-    python-version: 3.9
+    python-version: 3.11
 
 - uses: MDAnalysis/install-mdanalysis@main
   id: install-mdanalysis
@@ -36,12 +36,12 @@ Alternatively, you could use conda to install version 2.1.0:
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v6
 
-- name: Install conda Python 3.9
+- name: Install conda Python 3.11
   uses: conda-incubator/setup-miniconda@v2
   with:
-  python-version: 3.9
+  python-version: 3.11
   add-pip-as-python-dependency: true
   architecture: x64
   mamba-version: "*"
@@ -52,7 +52,7 @@ steps:
 - uses: MDAnalysis/install-mdanalysis@main
   id: install-mdanalysis
   with:
-    version: "2.1.0"
+    version: "2.10.0"
     install-tests: true
     installer: conda  # or mamba
     shell: bash -l {0}


### PR DESCRIPTION
Some maintenance to update the actions:
- setup-python: `v4` to `v6`.
- checkout: `v3` to `v6`.

and the versions of MDAnalysis: 
`*_DEVELOP_VERSION`, `*_LATEST_RELEASE`, `*_PREVIOUS_RELEASE`.

