### PR TITLE
Lowercase mdanalysis and mdanalysistests for conda installs

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -103,7 +103,7 @@ jobs:
       uses: mamba-org/setup-micromamba@v3
       with:
         environment-name: mda
-        create-args: |
+        create-args: >-
           python=${{ matrix.python-version }}
           pip
 
@@ -166,7 +166,7 @@ jobs:
         uses: mamba-org/setup-micromamba@v3
         with:
           environment-name: mda
-          create-args: |
+          create-args: >-
             python=${{ needs.gen-python-matrix.outputs.stable-python }}
             pip
 

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -104,7 +104,7 @@ jobs:
       with:
         environment-name: mda
         create-args: |
-          python==${{ matrix.python-version }}
+          python=${{ matrix.python-version }}
           pip
 
     - name: Install conda Python ${{ matrix.python-version }}
@@ -163,14 +163,12 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install mamba Python ${{ needs.gen-python-matrix.outputs.stable-python }}
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v3
         with:
-          environment-file: ./.github/test-environment.yaml
           environment-name: mda
-          extra-specs: |
-            python==${{ needs.gen-python-matrix.outputs.stable-python }}
+          create-args: |
+            python=${{ needs.gen-python-matrix.outputs.stable-python }}
             pip
-          channels: conda-forge
 
       - name: Install
         uses: ./

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -102,7 +102,6 @@ jobs:
       if: ${{ matrix.installer == 'micromamba' }}
       uses: mamba-org/setup-micromamba@v3
       with:
-        environment-file: false
         environment-name: mda
         create-args: |
           python==${{ matrix.python-version }}

--- a/action.yaml
+++ b/action.yaml
@@ -80,9 +80,9 @@ runs:
           _PACKAGE_SUFFIX="==${{ inputs.version }}"
         fi
         
-        _INSTALL_LINE="MDAnalysis${_PACKAGE_SUFFIX}"
+        _INSTALL_LINE="mdanalysis${_PACKAGE_SUFFIX}"
         if [[ "${{ inputs.install-tests }}" == "true" ]] ; then
-          _INSTALL_LINE="${_INSTALL_LINE} MDAnalysisTests${_PACKAGE_SUFFIX}"
+          _INSTALL_LINE="${_INSTALL_LINE} mdanalysistests${_PACKAGE_SUFFIX}"
         fi
 
         # special case develop


### PR DESCRIPTION
Looks like there might be a bug in the current available version of mamba that is causing issues with capitalized package names. Given that the names are actually normalized to lowercase anyways, it might just be easier to switch to that solely for conda installs.