### PR TITLE
remove use of anaconda defaults channel from CI

### DIFF
--- a/.github/test-environment.yaml
+++ b/.github/test-environment.yaml
@@ -1,7 +1,7 @@
 name: test
 channels:
   - conda-forge
-  - defaults
+  - nodefaults
 dependencies:
     # Base depends
   - python

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -115,7 +115,8 @@ jobs:
         add-pip-as-python-dependency: true
         architecture: x64
         mamba-version: "*"
-        channels: conda-forge, defaults
+        channels: conda-forge
+        conda-remove-defaults: true
         auto-update-conda: true
         show-channel-urls: true
 


### PR DESCRIPTION
- fix #17
- remove explicit use of anaconda defaults channel from setup-miniconda installation step
- use *nodefaults* in the environment yaml file